### PR TITLE
DRF 3.10 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,5 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+.idea

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Supported Django versions:
 * Django 1.11
 * Django 2.0
 
+Supported DRF versions:
+
+* at least DRF 3.10 or greater
+
 ### Requirements
 
 Make a proper setup for django-invitations.

--- a/rest_invitations/views.py
+++ b/rest_invitations/views.py
@@ -3,8 +3,7 @@ from invitations.adapters import get_invitations_adapter
 from invitations.app_settings import app_settings as invitations_settings
 from invitations.signals import invite_accepted
 from rest_framework import mixins, status, viewsets
-from rest_framework.decorators import (api_view, detail_route, list_route,
-                                       permission_classes)
+from rest_framework.decorators import (api_view, permission_classes, action)
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
@@ -35,7 +34,8 @@ class InvitationViewSet(
         invitation.save()
         invitation.send_invitation(request)
 
-    @detail_route(
+    @action(
+        detail=True,
         methods=['post'], permission_classes=[IsAuthenticated],
         url_path=SEND_URL
     )
@@ -45,7 +45,8 @@ class InvitationViewSet(
         content = {'detail': 'Invite sent'}
         return Response(content, status=status.HTTP_200_OK)
 
-    @list_route(
+    @action(
+        detail=False,
         methods=['post'], permission_classes=[IsAuthenticated],
         url_path=CREATE_AND_SEND_URL
     )
@@ -58,7 +59,8 @@ class InvitationViewSet(
         content = {'detail': 'Invite sent'}
         return Response(content, status=status.HTTP_200_OK)
 
-    @list_route(
+    @action(
+        detail=False,
         methods=['post'], permission_classes=[IsAuthenticated],
         url_path=SEND_MULTIPLE_URL
     )


### PR DESCRIPTION
In DRF 3.8 they have announced detail_route and list_route deprecation and it has been removed since 3.10

https://www.django-rest-framework.org/community/3.8-announcement/#deprecations