### PR TITLE
Silence deprecation warnings for Django 4

### DIFF
--- a/rest_invitations/serializers.py
+++ b/rest_invitations/serializers.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import get_user_model
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from invitations.adapters import get_invitations_adapter
 from invitations.exceptions import (AlreadyAccepted, AlreadyInvited,
                                     UserRegisteredEmail)

--- a/rest_invitations/urls.py
+++ b/rest_invitations/urls.py
@@ -11,7 +11,7 @@ router.register(r'{0}'.format(API_BASE_URL), InvitationViewSet)
 invitations_patterns = (
     [
         path(
-            r'^{0}/{1}/(?P<key>\w+)/?$'.format(
+            '{0}/{1}/<key>)/'.format(
                 API_BASE_URL, ACCEPT_INVITE_URL
             ),
             accept_invitation,
@@ -22,5 +22,5 @@ invitations_patterns = (
 )
 
 urlpatterns = router.urls + [
-    path(r'^', include(invitations_patterns)),
+    path('', include(invitations_patterns)),
 ]

--- a/rest_invitations/urls.py
+++ b/rest_invitations/urls.py
@@ -1,4 +1,5 @@
-from django.conf.urls import include, url
+from django.conf.urls import include
+from django.urls import path
 from rest_framework import routers
 
 from .app_settings import ACCEPT_INVITE_URL, API_BASE_URL
@@ -9,7 +10,7 @@ router.register(r'{0}'.format(API_BASE_URL), InvitationViewSet)
 
 invitations_patterns = (
     [
-        url(
+        path(
             r'^{0}/{1}/(?P<key>\w+)/?$'.format(
                 API_BASE_URL, ACCEPT_INVITE_URL
             ),
@@ -21,5 +22,5 @@ invitations_patterns = (
 )
 
 urlpatterns = router.urls + [
-    url(r'^', include(invitations_patterns)),
+    path(r'^', include(invitations_patterns)),
 ]


### PR DESCRIPTION
Removes these two warnings:

```
rest_invitations/urls.py:12: RemovedInDjango40Warning: django.conf.urls.url() is deprecated in favor of django.urls.re_path().
rest_invitations/serializers.py:17: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
```